### PR TITLE
docs: add required fields to operator deployment

### DIFF
--- a/example/deployment.yaml
+++ b/example/deployment.yaml
@@ -1,13 +1,16 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: etcd-operator
 spec:
+  selector:
+    matchLabels:
+      app: etcd-operator
   replicas: 1
   template:
     metadata:
       labels:
-        name: etcd-operator
+        app: etcd-operator
     spec:
       containers:
       - name: etcd-operator


### PR DESCRIPTION
kubectl create fails on modern k8s versions with error that label is
missing and apiVersion is unknown


Please read https://github.com/coreos/etcd-operator/blob/master/CONTRIBUTING.md#contribution-flow
