### PR TITLE
Mark cluster status failed when no pods are running or quorum is lost

### DIFF
--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -41,6 +41,7 @@ import (
 var (
 	reconcileInterval         = 8 * time.Second
 	podTerminationGracePeriod = int64(5)
+	errAllPodsDead = newFatalError("all etcd pods are dead.")
 )
 
 type clusterEventType string
@@ -246,8 +247,8 @@ func (c *Cluster) run() {
 				continue
 			}
 			if len(running) == 0 {
-				// TODO: how to handle this case?
-				c.logger.Warningf("all etcd pods are dead.")
+				// All pods are dead, cluster cannot recover so return error
+				rerr = errAllPodsDead
 				break
 			}
 

--- a/pkg/cluster/reconcile.go
+++ b/pkg/cluster/reconcile.go
@@ -16,7 +16,6 @@ package cluster
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	api "github.com/coreos/etcd-operator/pkg/apis/etcd/v1beta2"
@@ -30,7 +29,7 @@ import (
 )
 
 // ErrLostQuorum indicates that the etcd cluster lost its quorum.
-var ErrLostQuorum = errors.New("lost quorum")
+var ErrLostQuorum = newFatalError("lost quorum")
 
 // reconcile reconciles cluster current state to desired state specified by spec.
 // - it tries to reconcile the cluster to desired size.


### PR DESCRIPTION
Clusters that currently have all their pods killed or have lost
quorum will stay in a running phase while being completed dead.

This change marks the corresponding errors as being fatal which
lets the operator mark those clusters as failed.

Fixes coreos#2067, coreos#1973

Example status:

```
Status:
  Client Port:  2379
  Conditions:
    Last Transition Time:  2019-11-11T20:03:43Z
    Last Update Time:      2019-11-11T20:03:43Z
    Reason:                Cluster available
    Status:                True
    Type:                  Available
  Current Version:         3.2.25
  Members:
    Ready:
      etcd-cluster-64687hxm2r
      etcd-cluster-klb4cjqbbb
      etcd-cluster-qcfpqm495v
  Phase:           Failed
  Reason:          all etcd pods are dead.
  Service Name:    etcd-cluster-client
  Size:            3
  Target Version:  
```

Please read https://github.com/coreos/etcd-operator/blob/master/CONTRIBUTING.md#contribution-flow
