### PR TITLE
etcd-backup-operator: add prometheus-metrics.

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -396,7 +396,10 @@
 [[projects]]
   digest = "1:a22debd993d18b9203c985810f33f52e7583724800ee8d15e7d362e7175639d1"
   name = "github.com/prometheus/client_golang"
-  packages = ["prometheus"]
+  packages = [
+    "prometheus",
+    "prometheus/promhttp",
+  ]
   pruneopts = "NT"
   revision = "c5b7fccd204277076155f10851dad72b76a49317"
   version = "v0.8.0"
@@ -994,6 +997,7 @@
     "github.com/pborman/uuid",
     "github.com/pkg/errors",
     "github.com/prometheus/client_golang/prometheus",
+    "github.com/prometheus/client_golang/prometheus/promhttp",
     "github.com/sirupsen/logrus",
     "golang.org/x/oauth2",
     "golang.org/x/time/rate",
@@ -1004,6 +1008,7 @@
     "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1",
     "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset",
     "k8s.io/apimachinery/pkg/api/errors",
+    "k8s.io/apimachinery/pkg/api/meta",
     "k8s.io/apimachinery/pkg/api/resource",
     "k8s.io/apimachinery/pkg/apis/meta/v1",
     "k8s.io/apimachinery/pkg/fields",

--- a/cmd/backup-operator/main.go
+++ b/cmd/backup-operator/main.go
@@ -17,15 +17,12 @@ package main
 import (
 	"context"
 	"flag"
-	"os"
-	"runtime"
-	"time"
-
+	"fmt"
 	controller "github.com/coreos/etcd-operator/pkg/controller/backup-operator"
 	"github.com/coreos/etcd-operator/pkg/util/constants"
 	"github.com/coreos/etcd-operator/pkg/util/k8sutil"
 	version "github.com/coreos/etcd-operator/version"
-
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes"
@@ -34,6 +31,10 @@ import (
 	"k8s.io/client-go/tools/leaderelection"
 	"k8s.io/client-go/tools/leaderelection/resourcelock"
 	"k8s.io/client-go/tools/record"
+	"net/http"
+	"os"
+	"runtime"
+	"time"
 )
 
 var (
@@ -81,7 +82,8 @@ func main() {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-
+	http.Handle("/metrics", promhttp.Handler())
+	go http.ListenAndServe(fmt.Sprintf(":%d", 9091), nil)
 	leaderelection.RunOrDie(ctx, leaderelection.LeaderElectionConfig{
 		Lock:          rl,
 		LeaseDuration: 15 * time.Second,

--- a/pkg/backup/metrics/metrics.go
+++ b/pkg/backup/metrics/metrics.go
@@ -1,0 +1,35 @@
+package metrics
+
+import "github.com/prometheus/client_golang/prometheus"
+
+var (
+	BackupsAttemptedTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "etcd_operator",
+		Name:      "backups_attempt_total",
+		Help:      "Backups attempt by name and namespace",
+	},
+		[]string{"name", "namespace"},
+	)
+
+	BackupsSuccessTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "etcd_operator",
+		Name:      "backups_success_total",
+		Help:      "Backups success by name and namespace",
+	},
+		[]string{"name", "namespace"},
+	)
+
+	BackupsLastSuccess = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: "etcd_operator",
+		Name:      "backup_last_success",
+		Help:      "Timestamp of last successfull backup, by name and namespace",
+	},
+		[]string{"name", "namespace"},
+	)
+)
+
+func init() {
+	prometheus.MustRegister(BackupsAttemptedTotal)
+	prometheus.MustRegister(BackupsSuccessTotal)
+	prometheus.MustRegister(BackupsLastSuccess)
+}


### PR DESCRIPTION
Added a few metricts and an exporter to the backup operator.

Related to: https://github.com/coreos/etcd-operator/issues/2095

Removed gorilla mux


Please read https://github.com/coreos/etcd-operator/blob/master/CONTRIBUTING.md#contribution-flow
