### PR TITLE
Add support for SecretTypeTLS secrets

### DIFF
--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -371,7 +371,7 @@ func (c *Cluster) isPodPVEnabled() bool {
 }
 
 func (c *Cluster) createPod(members etcdutil.MemberSet, m *etcdutil.Member, state string) error {
-	pod := k8sutil.NewEtcdPod(m, members.PeerURLPairs(), c.cluster.Name, state, uuid.New(), c.cluster.Spec, c.cluster.AsOwner())
+	pod, err := k8sutil.NewEtcdPod(c.config.KubeCli, m, members.PeerURLPairs(), c.cluster.Name, c.cluster.Namespace, state, uuid.New(), c.cluster.Spec, c.cluster.AsOwner())
 	if c.isPodPVEnabled() {
 		pvc := k8sutil.NewEtcdPodPVC(m, *c.cluster.Spec.Pod.PersistentVolumeClaimSpec, c.cluster.Name, c.cluster.Namespace, c.cluster.AsOwner())
 		_, err := c.config.KubeCli.CoreV1().PersistentVolumeClaims(c.cluster.Namespace).Create(pvc)
@@ -386,7 +386,7 @@ func (c *Cluster) createPod(members etcdutil.MemberSet, m *etcdutil.Member, stat
 		}
 		k8sutil.AddEtcdVolumeToPod(pod, nil, tmpfs)
 	}
-	_, err := c.config.KubeCli.CoreV1().Pods(c.cluster.Namespace).Create(pod)
+	_, err = c.config.KubeCli.CoreV1().Pods(c.cluster.Namespace).Create(pod)
 	return err
 }
 

--- a/pkg/controller/restore-operator/sync.go
+++ b/pkg/controller/restore-operator/sync.go
@@ -223,8 +223,8 @@ func (r *Restore) createSeedMember(ec *api.EtcdCluster, svcAddr, namespace strin
 	ms := etcdutil.NewMemberSet(m)
 	backupURL := backupapi.BackupURLForRestore("http", svcAddr, clusterName, namespace)
 	ec.SetDefaults()
-	pod := k8sutil.NewSeedMemberPod(clusterName, ms, m, ec.Spec, owner, backupURL)
-	_, err := r.kubecli.Core().Pods(ec.Namespace).Create(pod)
+	pod, err := k8sutil.NewSeedMemberPod(r.kubecli, clusterName, namespace, ms, m, ec.Spec, owner, backupURL)
+	_, err = r.kubecli.Core().Pods(ec.Namespace).Create(pod)
 	return err
 }
 

--- a/pkg/util/k8sutil/pod_util.go
+++ b/pkg/util/k8sutil/pod_util.go
@@ -68,11 +68,14 @@ func containerWithRequirements(c v1.Container, r v1.ResourceRequirements) v1.Con
 	return c
 }
 
-func newEtcdProbe(isSecure bool) *v1.Probe {
+func newEtcdProbe(isSecure, isTLSSecret bool) *v1.Probe {
 	// etcd pod is healthy only if it can participate in consensus
 	cmd := "ETCDCTL_API=3 etcdctl endpoint status"
 	if isSecure {
 		tlsFlags := fmt.Sprintf("--cert=%[1]s/%[2]s --key=%[1]s/%[3]s --cacert=%[1]s/%[4]s", operatorEtcdTLSDir, etcdutil.CliCertFile, etcdutil.CliKeyFile, etcdutil.CliCAFile)
+		if isTLSSecret {
+			tlsFlags = fmt.Sprintf("--cert=%[1]s/%[2]s --key=%[1]s/%[3]s --cacert=%[1]s/%[4]s", operatorEtcdTLSDir, "tls.crt", "tls.key", "ca.crt")
+		}
 		cmd = fmt.Sprintf("ETCDCTL_API=3 etcdctl --endpoints=https://localhost:%d %s endpoint status", EtcdClientPort, tlsFlags)
 	}
 	return &v1.Probe{

--- a/pkg/util/k8sutil/tls.go
+++ b/pkg/util/k8sutil/tls.go
@@ -15,10 +15,11 @@
 package k8sutil
 
 import (
-	"github.com/coreos/etcd-operator/pkg/util/etcdutil"
-
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"k8s.io/client-go/kubernetes"
+	"github.com/coreos/etcd-operator/pkg/util/etcdutil"
 )
 
 type TLSData struct {
@@ -33,6 +34,15 @@ func GetTLSDataFromSecret(kubecli kubernetes.Interface, ns, se string) (*TLSData
 	if err != nil {
 		return nil, err
 	}
+
+	if secret.Type == v1.SecretTypeTLS {
+		return &TLSData{
+			CertData: secret.Data["tls.crt"],
+			KeyData:  secret.Data["tls.key"],
+			CAData:   secret.Data["ca.crt"],
+		}, nil
+	}
+
 	return &TLSData{
 		CertData: secret.Data[etcdutil.CliCertFile],
 		KeyData:  secret.Data[etcdutil.CliKeyFile],


### PR DESCRIPTION
Kubernetes knows specific TLS secrets (SecretTypeTLS). This kind of
secrets has specifically named fields (tls.crt, tls.key, ca.crt)
different from those supported by the etcd-operator. Such secretes
are e.g. generated by the cert-manager. This change adds support for
such secrets.

Please read https://github.com/coreos/etcd-operator/blob/master/CONTRIBUTING.md#contribution-flow
