### PR TITLE
Fix panic when duration is negative if backup hasn't yet occurred

### DIFF
--- a/pkg/controller/backup-operator/sync.go
+++ b/pkg/controller/backup-operator/sync.go
@@ -103,6 +103,9 @@ func (b *Backup) processItem(key string) error {
 
 			// duration = (Create date in seconds + backup interval in seconds) - current data in seconds
 			duration = int64(eb.CreationTimestamp.Time.Add(time.Duration(eb.Spec.BackupPolicy.BackupIntervalInSecond) * time.Second).Sub(time.Now()).Seconds())
+                        if duration <= 0 {
+                                duration = eb.Spec.BackupPolicy.BackupIntervalInSecond
+                        }
 			ticker = time.NewTicker(
 				time.Duration(duration) * time.Second)
 		} else { // if lastExecution already exists


### PR DESCRIPTION
This PR fixes a panic in the backup operator when determining when to schedule a backup if a backup hasn't yet occurred:

goroutine 27 [running]:
k8s.io/apimachinery/pkg/util/runtime.HandleCrash(0x0, 0x0, 0x0)
	/root/go/pkg/mod/k8s.io/apimachinery@v0.0.0-20190221084156-01f179d85dbc/pkg/util/runtime/runtime.go:58 +0x105
panic(0x1600ea0, 0xc0002e63f0)
	/root/sdk/go1.13.12/src/runtime/panic.go:679 +0x1b2
time.NewTicker(0xffffb5deac37e200, 0xc000000005)
	/root/sdk/go1.13.12/src/time/tick.go:23 +0x147
github.com/coreos/etcd-operator/pkg/controller/backup-operator.(*Backup).processItem(0xc0006d2210, 0xc0007a8540, 0x3b, 0x158c300, 0xc0007a02c0)
	/root/go/src/github.com/coreos/etcd-operator/pkg/controller/backup-operator/sync.go:110 +0x735
github.com/coreos/etcd-operator/pkg/controller/backup-operator.(*Backup).processNextItem(0xc0006d2210, 0x0)
	/root/go/src/github.com/coreos/etcd-operator/pkg/controller/backup-operator/sync.go:58 +0xf4
github.com/coreos/etcd-operator/pkg/controller/backup-operator.(*Backup).runWorker(0xc0006d2210)
	/root/go/src/github.com/coreos/etcd-operator/pkg/controller/backup-operator/sync.go:44 +0x2b
k8s.io/apimachinery/pkg/util/wait.JitterUntil.func1(0xc0002e6010)
	/root/go/pkg/mod/k8s.io/apimachinery@v0.0.0-20190221084156-01f179d85dbc/pkg/util/wait/wait.go:133 +0x5e
k8s.io/apimachinery/pkg/util/wait.JitterUntil(0xc0002e6010, 0x3b9aca00, 0x0, 0x1, 0xc0005a24e0)
	/root/go/pkg/mod/k8s.io/apimachinery@v0.0.0-20190221084156-01f179d85dbc/pkg/util/wait/wait.go:134 +0xf8
k8s.io/apimachinery/pkg/util/wait.Until(0xc0002e6010, 0x3b9aca00, 0xc0005a24e0)
	/root/go/pkg/mod/k8s.io/apimachinery@v0.0.0-20190221084156-01f179d85dbc/pkg/util/wait/wait.go:88 +0x4d
created by github.com/coreos/etcd-operator/pkg/controller/backup-operator.(*Backup).run
	/root/go/src/github.com/coreos/etcd-operator/pkg/controller/backup-operator/controller.go:55 +0x702