### PR TITLE
Change client port name based on TLS

### DIFF
--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -364,12 +364,12 @@ func (c *Cluster) Update(cl *api.EtcdCluster) {
 }
 
 func (c *Cluster) setupServices() error {
-	err := k8sutil.CreateClientService(c.config.KubeCli, c.cluster.Name, c.cluster.Namespace, c.cluster.AsOwner())
+	err := k8sutil.CreateClientService(c.config.KubeCli, c.cluster.Name, c.cluster.Namespace, c.cluster.AsOwner(), c.isSecureClient())
 	if err != nil {
 		return err
 	}
 
-	return k8sutil.CreatePeerService(c.config.KubeCli, c.cluster.Name, c.cluster.Namespace, c.cluster.AsOwner())
+	return k8sutil.CreatePeerService(c.config.KubeCli, c.cluster.Name, c.cluster.Namespace, c.cluster.AsOwner(), c.isSecureClient())
 }
 
 func (c *Cluster) isPodPVEnabled() bool {

--- a/pkg/util/k8sutil/k8sutil.go
+++ b/pkg/util/k8sutil/k8sutil.go
@@ -152,9 +152,17 @@ func PodWithNodeSelector(p *v1.Pod, ns map[string]string) *v1.Pod {
 	return p
 }
 
-func CreateClientService(kubecli kubernetes.Interface, clusterName, ns string, owner metav1.OwnerReference) error {
+func CreateClientService(kubecli kubernetes.Interface, clusterName, ns string, owner metav1.OwnerReference, tls bool) error {
+
+	var EtcdClientPortName string
+	if tls {
+		EtcdClientPortName = "https-client"
+	} else {
+		EtcdClientPortName = "http-client"
+	}
+
 	ports := []v1.ServicePort{{
-		Name:       "client",
+		Name:       EtcdClientPortName,
 		Port:       EtcdClientPort,
 		TargetPort: intstr.FromInt(EtcdClientPort),
 		Protocol:   v1.ProtocolTCP,
@@ -166,9 +174,17 @@ func ClientServiceName(clusterName string) string {
 	return clusterName + "-client"
 }
 
-func CreatePeerService(kubecli kubernetes.Interface, clusterName, ns string, owner metav1.OwnerReference) error {
+func CreatePeerService(kubecli kubernetes.Interface, clusterName, ns string, owner metav1.OwnerReference, tls bool) error {
+
+	var EtcdClientPortName string
+	if tls {
+		EtcdClientPortName = "https-client"
+	} else {
+		EtcdClientPortName = "http-client"
+	}
+
 	ports := []v1.ServicePort{{
-		Name:       "client",
+		Name:       EtcdClientPortName,
 		Port:       EtcdClientPort,
 		TargetPort: intstr.FromInt(EtcdClientPort),
 		Protocol:   v1.ProtocolTCP,


### PR DESCRIPTION
etcd fails to run in istio if tls is enabled and the client port name
doesn't start with https. This change will set the client port name to
http-client if it's running without TLS and https-client if it's running
with TLS.


Please read https://github.com/coreos/etcd-operator/blob/master/CONTRIBUTING.md#contribution-flow
