### PR TITLE
k8sutil: make client service annotations configurable

### DIFF
--- a/pkg/apis/etcd/v1beta2/cluster.go
+++ b/pkg/apis/etcd/v1beta2/cluster.go
@@ -97,6 +97,9 @@ type ClusterSpec struct {
 	// Updating Pod does not take effect on any existing etcd pods.
 	Pod *PodPolicy `json:"pod,omitempty"`
 
+	// Service defines the policy to create etcd services
+	Service *ServicePolicy `json:"service,omitempty"`
+
 	// etcd cluster TLS configuration
 	TLS *TLSPolicy `json:"TLS,omitempty"`
 }
@@ -167,6 +170,13 @@ type PodPolicy struct {
 	// The default is to not use memory as the storage medium
 	// No effect if persistent volume is used
 	Tmpfs bool `json:"tmpfs,omitempty"`
+}
+
+// ServicePolicy defines the policy to create pod for the etcd container.
+type ServicePolicy struct {
+	// Annotations specifies the annotations to attach to services the operator creates for the
+	// etcd cluster.
+	Annotations map[string]string `json:"annotations,omitempty"`
 }
 
 // TODO: move this to initializer

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -364,12 +364,12 @@ func (c *Cluster) Update(cl *api.EtcdCluster) {
 }
 
 func (c *Cluster) setupServices() error {
-	err := k8sutil.CreateClientService(c.config.KubeCli, c.cluster.Name, c.cluster.Namespace, c.cluster.AsOwner(), c.isSecureClient())
+	err := k8sutil.CreateClientService(c.config.KubeCli, c.cluster.Name, c.cluster.Namespace, c.cluster.AsOwner(), c.isSecureClient(), c.cluster.Spec.Service)
 	if err != nil {
 		return err
 	}
 
-	return k8sutil.CreatePeerService(c.config.KubeCli, c.cluster.Name, c.cluster.Namespace, c.cluster.AsOwner(), c.isSecureClient())
+	return k8sutil.CreatePeerService(c.config.KubeCli, c.cluster.Name, c.cluster.Namespace, c.cluster.AsOwner(), c.isSecureClient(), c.cluster.Spec.Service)
 }
 
 func (c *Cluster) isPodPVEnabled() bool {

--- a/pkg/util/k8sutil/service_utils.go
+++ b/pkg/util/k8sutil/service_utils.go
@@ -1,0 +1,30 @@
+// Copyright 2016 The etcd-operator Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package k8sutil
+
+import (
+	"k8s.io/api/core/v1"
+	api "github.com/coreos/etcd-operator/pkg/apis/etcd/v1beta2"
+)
+
+func applyServicePolicy(service *v1.Service, policy *api.ServicePolicy) {
+	if policy == nil {
+		return
+	}
+
+	for key, value := range policy.Annotations {
+		service.ObjectMeta.Annotations[key] = value
+	}
+}

--- a/pkg/util/k8sutil/service_utils_test.go
+++ b/pkg/util/k8sutil/service_utils_test.go
@@ -1,0 +1,96 @@
+// Copyright 2016 The etcd-operator Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package k8sutil
+
+import (
+	"testing"
+
+  "k8s.io/api/core/v1"
+  metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	api "github.com/coreos/etcd-operator/pkg/apis/etcd/v1beta2"
+  "reflect"
+)
+
+func TestApplyNilServicePolicy(t *testing.T) {
+  svc := &v1.Service{
+              ObjectMeta: metav1.ObjectMeta{
+                Name: "service",
+                Annotations: map[string]string{},
+                },
+              }
+	var policy *api.ServicePolicy = nil
+  expected := svc.GetObjectMeta().GetAnnotations()
+	applyServicePolicy(svc, policy)
+  actual := svc.GetObjectMeta().GetAnnotations()
+	if !reflect.DeepEqual(expected, actual) {
+		t.Errorf("expect expected=%v, got=%v", expected, actual)
+	}
+}
+
+func TestApplyEmptyServicePolicy(t *testing.T) {
+  svc := &v1.Service{
+              ObjectMeta: metav1.ObjectMeta{
+                Name: "service",
+                Annotations: map[string]string{},
+                },
+              }
+	policy := &api.ServicePolicy{}
+  expected := svc.GetObjectMeta().GetAnnotations()
+	applyServicePolicy(svc, policy)
+  actual := svc.GetObjectMeta().GetAnnotations()
+	if !reflect.DeepEqual(expected, actual) {
+		t.Errorf("expect expected=%v, got=%v", expected, actual)
+	}
+}
+
+func TestApplyEmptyAnnotationsServicePolicy(t *testing.T) {
+  svc := &v1.Service{
+              ObjectMeta: metav1.ObjectMeta{
+                Name: "service",
+                Annotations: map[string]string{},
+                },
+              }
+	policy := &api.ServicePolicy{
+		Annotations: map[string]string{},
+	}
+  expected := svc.GetObjectMeta().GetAnnotations()
+	applyServicePolicy(svc, policy)
+  actual := svc.GetObjectMeta().GetAnnotations()
+	if !reflect.DeepEqual(expected, actual) {
+		t.Errorf("expect expected=%v, got=%v", expected, actual)
+	}
+}
+
+func TestApplyServicePolicyWithAnnotation(t *testing.T) {
+  svc := &v1.Service{
+              ObjectMeta: metav1.ObjectMeta{
+                Name: "service",
+                Annotations: map[string]string{},
+                },
+              }
+  annotations := map[string]string{
+    "key1": "value2",
+		"key2": "value2",
+  }
+
+	policy := &api.ServicePolicy{
+    Annotations: annotations,
+  }
+	applyServicePolicy(svc, policy)
+  actual := svc.GetObjectMeta().GetAnnotations()
+	if !reflect.DeepEqual(annotations, actual) {
+		t.Errorf("expect expected=%v, got=%v", annotations, actual)
+	}
+}


### PR DESCRIPTION
This PR extends the operator with an option to create annotations to the client service that the operator creates for the cluster