### PR TITLE
pkg/util: make more options from client service configurable

### DIFF
--- a/pkg/apis/etcd/v1beta2/cluster.go
+++ b/pkg/apis/etcd/v1beta2/cluster.go
@@ -177,6 +177,12 @@ type ServicePolicy struct {
 	// Annotations specifies the annotations to attach to services the operator creates for the
 	// etcd cluster.
 	Annotations map[string]string `json:"annotations,omitempty"`
+
+	// Overrides the routing service traffic to pods with label keys and
+	// values matching this selector.
+	// More info: https://kubernetes.io/docs/concepts/services-networking/service/
+	// +optional
+	Selector map[string]string `json:"selector,omitempty"`
 }
 
 // TODO: move this to initializer

--- a/pkg/apis/etcd/v1beta2/cluster.go
+++ b/pkg/apis/etcd/v1beta2/cluster.go
@@ -178,6 +178,10 @@ type ServicePolicy struct {
 	// etcd cluster.
 	Annotations map[string]string `json:"annotations,omitempty"`
 
+	// Overrides the name of the service created
+	// +optional
+	Name string `json:"name,omitempty"`
+
 	// Overrides the routing service traffic to pods with label keys and
 	// values matching this selector.
 	// More info: https://kubernetes.io/docs/concepts/services-networking/service/

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -204,7 +204,7 @@ func (c *Cluster) run(ctx context.Context) {
 	if err := c.setupServices(ctx); err != nil {
 		c.logger.Errorf("fail to setup etcd services: %v", err)
 	}
-	c.status.ServiceName = k8sutil.ClientServiceName(c.cluster.Name)
+	c.status.ServiceName = k8sutil.ClientServiceName(c.cluster.Name, c.cluster.Spec.Service)
 	c.status.ClientPort = k8sutil.EtcdClientPort
 
 	c.status.SetPhase(api.ClusterPhaseRunning)

--- a/pkg/util/k8sutil/k8sutil.go
+++ b/pkg/util/k8sutil/k8sutil.go
@@ -168,10 +168,13 @@ func CreateClientService(ctx context.Context, kubecli kubernetes.Interface, clus
 		TargetPort: intstr.FromInt(EtcdClientPort),
 		Protocol:   v1.ProtocolTCP,
 	}}
-	return createService(ctx, kubecli, ClientServiceName(clusterName), clusterName, ns, "", ports, owner, false, policy)
+	return createService(ctx, kubecli, ClientServiceName(clusterName, policy), clusterName, ns, "", ports, owner, false, policy)
 }
 
-func ClientServiceName(clusterName string) string {
+func ClientServiceName(clusterName string, policy *api.ServicePolicy) string {
+	if policy != nil && len(policy.Name) > 0 {
+		return policy.Name
+	}
 	return clusterName + "-client"
 }
 

--- a/pkg/util/k8sutil/k8sutils_test.go
+++ b/pkg/util/k8sutil/k8sutils_test.go
@@ -47,3 +47,39 @@ func TestSetBusyboxImageName(t *testing.T) {
 		t.Errorf("expect image=%s, get=%s", expected, image)
 	}
 }
+
+func TestClientServiceNameNilPolicy(t *testing.T) {
+	clusterName := "clusterName"
+	var policy *api.ServicePolicy = nil
+
+	svcName := ClientServiceName(clusterName, policy)
+	expected := "clusterName-client"
+	if svcName != expected {
+		t.Errorf("expect svcName=%s, got=%s", expected, svcName)
+	}
+}
+
+func TestClientServiceNameWithEmptyNamePolicy(t *testing.T) {
+	clusterName := "clusterName"
+	policy := &api.ServicePolicy{
+		Name: "",
+	}
+	svcName := ClientServiceName(clusterName, policy)
+	expected := "clusterName-client"
+	if svcName != expected {
+		t.Errorf("expect svcName=%s, got=%s", expected, svcName)
+	}
+}
+
+func TestClientServiceNameWithNamePolicy(t *testing.T) {
+	clusterName := "clusterName"
+	policy := &api.ServicePolicy{
+		Name: "clusterNameCustom",
+	}
+
+	svcName := ClientServiceName(clusterName, policy)
+	expected := policy.Name
+	if svcName != expected {
+		t.Errorf("expect svcName=%s, got=%s", expected, svcName)
+	}
+}

--- a/pkg/util/k8sutil/service_utils.go
+++ b/pkg/util/k8sutil/service_utils.go
@@ -24,6 +24,10 @@ func applyServicePolicy(service *v1.Service, policy *api.ServicePolicy) {
 		return
 	}
 
+	if len(policy.Selector) != 0 {
+		service.Spec.Selector = policy.Selector
+	}
+
 	for key, value := range policy.Annotations {
 		service.ObjectMeta.Annotations[key] = value
 	}

--- a/pkg/util/k8sutil/service_utils_test.go
+++ b/pkg/util/k8sutil/service_utils_test.go
@@ -94,3 +94,54 @@ func TestApplyServicePolicyWithAnnotation(t *testing.T) {
 		t.Errorf("expect expected=%v, got=%v", annotations, actual)
 	}
 }
+
+func TestApplyServicePolicyEmptySelector(t *testing.T) {
+	selector := map[string]string{
+		"key1": "value1",
+		"key2": "value2",
+	}
+	svc := &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "service",
+		},
+		Spec: v1.ServiceSpec{
+			Selector:  selector,
+		},
+	}
+	policy := &api.ServicePolicy{
+		Selector: map[string]string{},
+	}
+	applyServicePolicy(svc, policy)
+	actual := svc.Spec.Selector
+	if !reflect.DeepEqual(selector, actual) {
+		t.Errorf("expect expected=%v, got=%v", selector, actual)
+	}
+}
+
+func TestApplyServicePolicyWithSelector(t *testing.T) {
+	selector := map[string]string{
+		"key1": "value1",
+		"key2": "value2",
+	}
+	svc := &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "service",
+		},
+		Spec: v1.ServiceSpec{
+			Selector:  selector,
+		},
+	}
+	customSelector := map[string]string{
+		"key3": "value3",
+		"key4": "value4",
+	}
+
+	policy := &api.ServicePolicy{
+		Selector: customSelector,
+	}
+	applyServicePolicy(svc, policy)
+	actual := svc.Spec.Selector
+	if !reflect.DeepEqual(customSelector, actual) {
+		t.Errorf("expect expected=%v, got=%v", selector, actual)
+	}
+}


### PR DESCRIPTION
This PR enables the option to override the name and selector of the client service created by the operator.

This custom selector is useful when you want to send your traffic through an etcd proxy layer, for instance.