### PR TITLE
ci(e2e): use default KUBECONFIG path

### DIFF
--- a/.github/workflows/go-test-e2e.yml
+++ b/.github/workflows/go-test-e2e.yml
@@ -60,7 +60,7 @@ jobs:
           docker login docker.pkg.github.com -u marlinc -p "${GITHUB_PACKAGE_REGISTRY_TOKEN}"
           docker pull $TEST_IMAGE
           docker pull $OPERATOR_IMAGE
-          export KUBECONFIG="$(kind get kubeconfig-path)"
+          export KUBECONFIG="${HOME}/.kube/config"
           kind load docker-image $TEST_IMAGE
           kind load docker-image $OPERATOR_IMAGE
           hack/ci/run_e2e

--- a/test/logcollector/main.go
+++ b/test/logcollector/main.go
@@ -60,7 +60,7 @@ func main() {
 	_, informer := cache.NewIndexerInformer(podListWatcher, &v1.Pod{}, 0, cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			go func(pod *v1.Pod, namespace, logsDir string) {
-				watcher, err := kubecli.CoreV1().Pods(namespace).Watch(metav1.SingleObject(metav1.ObjectMeta{Name: pod.Name}))
+				watcher, err := kubecli.CoreV1().Pods(namespace).Watch(context.Background(), metav1.SingleObject(metav1.ObjectMeta{Name: pod.Name}))
 				if err != nil {
 					logrus.Errorf("failed to watch for pod (%s): %v", pod.Name, err)
 					return
@@ -83,7 +83,7 @@ func main() {
 					go func(c v1.Container) {
 						logOption := &v1.PodLogOptions{Follow: true, Container: c.Name}
 						req := kubecli.CoreV1().Pods(namespace).GetLogs(pod.Name, logOption)
-						readCloser, err := req.Stream()
+						readCloser, err := req.Stream(context.Background())
 						if err != nil {
 							logrus.Errorf("failed to open stream for pod (%s): %v", pod.Name, err)
 							return


### PR DESCRIPTION
Please read https://github.com/coreos/etcd-operator/blob/master/CONTRIBUTING.md#contribution-flow
